### PR TITLE
Fix race conditions when starting async tasks

### DIFF
--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ExpirationDateActivity.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ExpirationDateActivity.java
@@ -89,8 +89,6 @@ public class ExpirationDateActivity extends AppCompatActivity implements CvCamer
         mTextRecognizer = new TextRecognizer.Builder(getApplicationContext()).build();
 
         mExpDateResultView = findViewById(R.id.exp_date_result_view);
-
-        ocrTask = new OCRTask();
     }
 
     @Override
@@ -149,7 +147,7 @@ public class ExpirationDateActivity extends AppCompatActivity implements CvCamer
     public Mat onCameraFrame(CvCameraViewFrame inputFrame) {
         System.gc();
 
-        if (ocrTask.getStatus() != AsyncTask.Status.RUNNING) {
+        if (ocrTask == null || ocrTask.getStatus() == AsyncTask.Status.FINISHED) {
             ocrTask = new OCRTask();
             ocrTask.execute(inputFrame.rgba().clone());
         }

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityActivity.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityActivity.java
@@ -159,9 +159,6 @@ public class ImageQualityActivity extends AppCompatActivity implements CvCameraV
         mInstructionText = findViewById(R.id.textInstruction);
 
         setProgressUI(mCurrentState);
-
-        initTask = new FeatureMathchingTask();
-        qualityCheckTask = new ImageQualityCheckTask();
     }
 
     @Override
@@ -275,7 +272,7 @@ public class ImageQualityActivity extends AppCompatActivity implements CvCameraV
 
         switch (mCurrentState) {
             case INITIALIZATION:
-                if (initTask.getStatus() != AsyncTask.Status.RUNNING ) {
+                if (initTask == null || initTask.getStatus() == AsyncTask.Status.FINISHED ) {
                     initTask = new FeatureMathchingTask();
                     initTask.execute(grayMat);
                 }
@@ -303,8 +300,7 @@ public class ImageQualityActivity extends AppCompatActivity implements CvCameraV
             case QUALITY_CHECK:
                 if (isCaptured)
                     return null;
-
-                if (qualityCheckTask.getStatus() != AsyncTask.Status.RUNNING) {
+                if (qualityCheckTask == null || qualityCheckTask.getStatus() == AsyncTask.Status.FINISHED) {
                     qualityCheckTask = new ImageQualityCheckTask();
                     Log.d(TAG, "rgbaMat 0 Size: "+rgbaMat.size().toString() + ", grayMat 1 Size: "+grayMat.size().toString());
                     qualityCheckTask.execute(rgbaMat.clone(), grayMat);


### PR DESCRIPTION
changed: previously, this would trigger a new task if the old task was PENDING,
meaning multiple tasks could become queued at the same time.  This is a race
condition which may have been affecting performance.