### PR TITLE
Add attributes to optionally hide viewfinder and feedback

### DIFF
--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -77,6 +77,8 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
     private View mProgressBackgroundView;
     private TextView mInstructionText;
     private State mCurrentState = State.QUALITY_CHECK;
+    private boolean showViewport;
+    private boolean showFeedback;
 
     private long timeTaken = 0;
 
@@ -103,14 +105,14 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
 
         TypedArray styleAttrs = context.getTheme().obtainStyledAttributes(
                 attrs, R.styleable.ImageQualityView, 0, 0);
-        boolean showViewport = styleAttrs.getBoolean(R.styleable.ImageQualityView_showViewport, true);
-        boolean showFeedback = styleAttrs.getBoolean(R.styleable.ImageQualityView_showFeedback, true);
+        showViewport = styleAttrs.getBoolean(R.styleable.ImageQualityView_showViewport, true);
+        showFeedback = styleAttrs.getBoolean(R.styleable.ImageQualityView_showFeedback, true);
 
         mTextureView = findViewById(R.id.texture);
 
         timeTaken = System.currentTimeMillis();
 
-        initViews(showViewport, showFeedback);
+        initViews();
 
     }
 
@@ -837,7 +839,7 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
         }
     };
 
-    private void initViews(boolean showViewport, boolean showFeedback) {
+    private void initViews() {
         mActivity.setTitle("Image Quality Checker");
 
         mActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
@@ -860,7 +862,9 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
         mCaptureProgressBar.setProgress(0);
         mInstructionText = findViewById(R.id.textInstruction);
 
-        if (!showFeedback) {
+        if (showFeedback) {
+            setProgressUI(mCurrentState);
+        } else {
             mImageQualityFeedbackView.setVisibility(GONE);
             mProgressBackgroundView.setVisibility(GONE);
             mProgress.setVisibility(GONE);
@@ -868,8 +872,6 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
             mInstructionText.setVisibility(GONE);
             mCaptureProgressBar.setVisibility(GONE);
         }
-
-        setProgressUI(mCurrentState);
     }
 
     private void setProgressUI(State CurrentState) {

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -14,8 +14,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
+import android.content.res.TypedArray;
 import android.graphics.ImageFormat;
 import android.graphics.Matrix;
 import android.graphics.RectF;
@@ -39,11 +38,8 @@ import android.os.HandlerThread;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.text.Html;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Size;
 import android.util.SparseIntArray;
@@ -58,17 +54,9 @@ import android.widget.Toast;
 
 import org.opencv.android.BaseLoaderCallback;
 import org.opencv.android.LoaderCallbackInterface;
-import org.opencv.android.Utils;
 
 import org.opencv.core.Mat;;
-import org.opencv.core.MatOfKeyPoint;
 
-import org.opencv.features2d.BFMatcher;
-import org.opencv.features2d.BRISK;
-
-import org.opencv.imgproc.Imgproc;
-
-import java.io.File;
 import java.util.Arrays;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -113,11 +101,16 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
         }
         inflate(context, R.layout.image_quality_view, this);
 
+        TypedArray styleAttrs = context.getTheme().obtainStyledAttributes(
+                attrs, R.styleable.ImageQualityView, 0, 0);
+        boolean showViewport = styleAttrs.getBoolean(R.styleable.ImageQualityView_showViewport, true);
+        boolean showFeedback = styleAttrs.getBoolean(R.styleable.ImageQualityView_showFeedback, true);
+
         mTextureView = findViewById(R.id.texture);
 
         timeTaken = System.currentTimeMillis();
 
-        initViews();
+        initViews(showViewport, showFeedback);
 
     }
 
@@ -844,7 +837,7 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
         }
     };
 
-    private void initViews() {
+    private void initViews(boolean showViewport, boolean showFeedback) {
         mActivity.setTitle("Image Quality Checker");
 
         mActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
@@ -853,7 +846,11 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
         // Instructions are set here
 
         mViewport = findViewById(R.id.img_quality_check_viewport);
-        mViewport.setOnClickListener(this);
+        if (showViewport) {
+            mViewport.setOnClickListener(this);
+        } else {
+            mViewport.setVisibility(GONE);
+        }
         mImageQualityFeedbackView = findViewById(R.id.img_quality_feedback_view);
         mProgress = findViewById(R.id.progressCircularBar);
         mProgressBackgroundView = findViewById(R.id.progressBackground);
@@ -862,6 +859,15 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
         mCaptureProgressBar.setMax(CAPTURE_COUNT);
         mCaptureProgressBar.setProgress(0);
         mInstructionText = findViewById(R.id.textInstruction);
+
+        if (!showFeedback) {
+            mImageQualityFeedbackView.setVisibility(GONE);
+            mProgressBackgroundView.setVisibility(GONE);
+            mProgress.setVisibility(GONE);
+            mProgressText.setVisibility(GONE);
+            mInstructionText.setVisibility(GONE);
+            mCaptureProgressBar.setVisibility(GONE);
+        }
 
         setProgressUI(mCurrentState);
     }

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -417,7 +417,7 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
                         //Log.d(TAG, "FOCUS STATE: unknown state " + result.get(CaptureResult.CONTROL_AF_STATE).toString());
                     }
 
-                    if (previousFocusState != mFocusState) {
+                    if (showFeedback && previousFocusState != mFocusState) {
                         mActivity.runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
@@ -875,6 +875,10 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
     }
 
     private void setProgressUI(State CurrentState) {
+        if (!showFeedback) {
+            return;
+        }
+
         switch (CurrentState) {
             case QUALITY_CHECK:
                 mActivity.runOnUiThread(new Runnable() {
@@ -904,6 +908,10 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
     }
 
     private void displayQualityResult(ImageProcessor.SizeResult sizeResult, boolean isCentered, boolean isRightOrientation, boolean isSharp, ImageProcessor.ExposureResult exposureResult) {
+        if (!showFeedback) {
+            return;
+        }
+
         FocusState currFocusState;
 
         synchronized (focusStateLock) {
@@ -939,6 +947,10 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
     }
 
     private void displayQualityResultFocusChanged() {
+        if (!showFeedback) {
+            return;
+        }
+
         FocusState currFocusState;
 
         synchronized (focusStateLock) {

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -12,4 +12,8 @@
         <attr name="heightScale" format="float" />
         <attr name="widthScale" format="float" />
     </declare-styleable>
+    <declare-styleable name="ImageQualityView">
+        <attr name="showViewport" format="boolean" />
+        <attr name="showFeedback" format="boolean"/>
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
`showViewfinder` and `showFeedback` default to true, and nothing should change when they're true. When set to false, `ImageQualityView` renders what the camera sees and nothing more, allowing us to draw our own UI and show our own feedback.