### PR TITLE
Add support for ImageQualityViewListener

### DIFF
--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityActivity.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityActivity.java
@@ -57,27 +57,32 @@ public class ImageQualityActivity extends Activity implements ImageQualityView.I
         Log.i("ImageQualityActivity", "Detected and Passed!");
         final ImageQualityActivity self = this;
 
-        byte[] captureByteArray = ImageUtil.matToRotatedByteArray(captureResult.resultMat);
-        byte[] windowByteArray = ImageUtil.matToRotatedByteArray(interpretationResult.resultMat);
-        if (mImageQualityView.isExternalIntent()) {
-            Intent i = new Intent();
+        final byte[] captureByteArray = ImageUtil.matToRotatedByteArray(captureResult.resultMat);
+        final byte[] windowByteArray = ImageUtil.matToRotatedByteArray(interpretationResult.resultMat);
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (mImageQualityView.isExternalIntent()) {
+                    Intent i = new Intent();
 
-            i.putExtra("data", captureByteArray);
-            i.putExtra("timeTaken", timeTaken);
+                    i.putExtra("data", captureByteArray);
+                    i.putExtra("timeTaken", timeTaken);
 
-            setResult(Activity.RESULT_OK, i);
-            finish();
-        } else {
-            Intent i = new Intent(self, ImageResultActivity.class);
-            i.addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT);
-            i.putExtra("captured", captureByteArray);
-            i.putExtra("window", windowByteArray);
-            i.putExtra("control", interpretationResult.control);
-            i.putExtra("testA", interpretationResult.testA);
-            i.putExtra("testB", interpretationResult.testB);
-            i.putExtra("timeTaken", timeTaken);
-            startActivity(i);
-        }
+                    setResult(Activity.RESULT_OK, i);
+                    finish();
+                } else {
+                    Intent i = new Intent(self, ImageResultActivity.class);
+                    i.addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT);
+                    i.putExtra("captured", captureByteArray);
+                    i.putExtra("window", windowByteArray);
+                    i.putExtra("control", interpretationResult.control);
+                    i.putExtra("testA", interpretationResult.testA);
+                    i.putExtra("testB", interpretationResult.testB);
+                    i.putExtra("timeTaken", timeTaken);
+                    startActivity(i);
+                }
+            }
+        });
         return ImageQualityView.RDTDectedResult.STOP;
     }
 }

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityActivity.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityActivity.java
@@ -3,8 +3,11 @@ package edu.washington.cs.ubicomplab.rdt_reader;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
-public class ImageQualityActivity extends Activity {
+import org.opencv.core.Mat;
+
+public class ImageQualityActivity extends Activity implements ImageQualityView.ImageQualityViewListener {
     ImageQualityView mImageQualityView;
 
     @Override
@@ -12,6 +15,7 @@ public class ImageQualityActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_image_quality);
         mImageQualityView = findViewById(R.id.imageQualityView);
+        mImageQualityView.setImageQualityViewListener(this);
     }
 
 
@@ -35,5 +39,45 @@ public class ImageQualityActivity extends Activity {
             Intent intent = new Intent(this, MainActivity.class);
             startActivity(intent);
         }
+    }
+
+    @Override
+    public void onRDTCameraReady() {
+    }
+
+    @Override
+    public ImageQualityView.RDTDectedResult onRDTDetected(
+            final ImageProcessor.CaptureResult captureResult,
+            final ImageProcessor.InterpretationResult interpretationResult,
+            final long timeTaken) {
+        Log.i("ImageQualityActivity", "Detected!");
+        if (!captureResult.allChecksPassed || interpretationResult == null || !interpretationResult.control) {
+            return ImageQualityView.RDTDectedResult.CONTINUE;
+        }
+        Log.i("ImageQualityActivity", "Detected and Passed!");
+        final ImageQualityActivity self = this;
+
+        byte[] captureByteArray = ImageUtil.matToRotatedByteArray(captureResult.resultMat);
+        byte[] windowByteArray = ImageUtil.matToRotatedByteArray(interpretationResult.resultMat);
+        if (mImageQualityView.isExternalIntent()) {
+            Intent i = new Intent();
+
+            i.putExtra("data", captureByteArray);
+            i.putExtra("timeTaken", timeTaken);
+
+            setResult(Activity.RESULT_OK, i);
+            finish();
+        } else {
+            Intent i = new Intent(self, ImageResultActivity.class);
+            i.addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT);
+            i.putExtra("captured", captureByteArray);
+            i.putExtra("window", windowByteArray);
+            i.putExtra("control", interpretationResult.control);
+            i.putExtra("testA", interpretationResult.testA);
+            i.putExtra("testB", interpretationResult.testB);
+            i.putExtra("timeTaken", timeTaken);
+            startActivity(i);
+        }
+        return ImageQualityView.RDTDectedResult.STOP;
     }
 }

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -348,32 +348,27 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
                 interpretationResult = processor.interpretResult(captureResult.resultMat);
 
             }
-            final ImageProcessor.InterpretationResult finalInterpretationResult = interpretationResult;
             imageQueue.remove();
             image.close();
-            mActivity.runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    RDTDectedResult result = RDTDectedResult.CONTINUE;
-                    if (mImageQualityViewListener != null) {
-                        result = mImageQualityViewListener.onRDTDetected(
-                                captureResult,
-                                finalInterpretationResult,
-                                System.currentTimeMillis() - timeTaken
-                        );
-                    }
-                    if (captureResult.resultMat != null) {
-                        captureResult.resultMat.release();
-                    }
-                    if (finalInterpretationResult != null &&
-                            finalInterpretationResult.resultMat != null) {
-                        finalInterpretationResult.resultMat.release();
-                    }
-                    if (result == RDTDectedResult.STOP) {
-                        mOnImageAvailableThread.interrupt();
-                    }
-                }
-            });
+
+            RDTDectedResult result = RDTDectedResult.CONTINUE;
+            if (mImageQualityViewListener != null) {
+                result = mImageQualityViewListener.onRDTDetected(
+                        captureResult,
+                        interpretationResult,
+                        System.currentTimeMillis() - timeTaken
+                );
+            }
+            if (captureResult.resultMat != null) {
+                captureResult.resultMat.release();
+            }
+            if (interpretationResult != null &&
+                    interpretationResult.resultMat != null) {
+                interpretationResult.resultMat.release();
+            }
+            if (result == RDTDectedResult.STOP) {
+                mOnImageAvailableThread.interrupt();
+            }
 
             return null;
         }

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -96,12 +96,23 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
 
     private FocusState mFocusState = FocusState.INACTIVE;
 
+    private ImageQualityViewListener mImageQualityViewListener;
+
     private enum State {
         QUALITY_CHECK, FINAL_CHECK
     }
 
     private enum FocusState {
         INACTIVE, FOCUSING, FOCUSED, UNFOCUSED
+    }
+
+    public interface ImageQualityViewListener {
+        void onRDTCameraReady();
+        void onRDTDetected(
+                String base64Img,
+                ImageProcessor.CaptureResult captureResult,
+                ImageProcessor.InterpretationResult interpretationResult
+        );
     }
 
     public ImageQualityView(Context context, AttributeSet attrs) {
@@ -124,6 +135,10 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
     public boolean isExternalIntent() {
         Intent i = mActivity.getIntent();
         return i != null && "medic.mrdt.verify".equals(i.getAction());
+    }
+
+    public void setImageQualityViewListener(ImageQualityViewListener listener) {
+        mImageQualityViewListener = listener;
     }
 
     /**
@@ -339,7 +354,21 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
                     imageQueue.remove();
                     image.close();
                 }
+                if (mImageQualityViewListener != null) {
+                    mImageQualityViewListener.onRDTDetected(
+                            ImageUtil.matToBase64(captureResult.resultMat),
+                            captureResult,
+                            interpretationResult
+                    );
+                }
             } else {
+                if (mImageQualityViewListener != null) {
+                    mImageQualityViewListener.onRDTDetected(
+                            ImageUtil.matToBase64(captureResult.resultMat),
+                            captureResult,
+                            null
+                    );
+                }
                 imageQueue.remove();
                 image.close();
             }

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -354,22 +354,23 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
             mActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
+                    RDTDectedResult result = RDTDectedResult.CONTINUE;
                     if (mImageQualityViewListener != null) {
-                        RDTDectedResult result = mImageQualityViewListener.onRDTDetected(
+                        result = mImageQualityViewListener.onRDTDetected(
                                 captureResult,
                                 finalInterpretationResult,
                                 System.currentTimeMillis() - timeTaken
                         );
-                        if (captureResult.resultMat != null) {
-                            captureResult.resultMat.release();
-                        }
-                        if (finalInterpretationResult != null &&
-                                finalInterpretationResult.resultMat != null) {
-                            finalInterpretationResult.resultMat.release();
-                        }
-                        if (result == RDTDectedResult.STOP) {
-                            mOnImageAvailableThread.interrupt();
-                        }
+                    }
+                    if (captureResult.resultMat != null) {
+                        captureResult.resultMat.release();
+                    }
+                    if (finalInterpretationResult != null &&
+                            finalInterpretationResult.resultMat != null) {
+                        finalInterpretationResult.resultMat.release();
+                    }
+                    if (result == RDTDectedResult.STOP) {
+                        mOnImageAvailableThread.interrupt();
                     }
                 }
             });

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -685,6 +685,9 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
                 return;
             }
             mCaptureSession = cameraCaptureSession;
+            if (mImageQualityViewListener != null) {
+                mImageQualityViewListener.onRDTCameraReady();
+            }
 
             updateRepeatingRequest();
         }

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -360,8 +360,11 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
                                 finalInterpretationResult,
                                 System.currentTimeMillis() - timeTaken
                         );
-                        captureResult.resultMat.release();
-                        if (finalInterpretationResult != null) {
+                        if (captureResult.resultMat != null) {
+                            captureResult.resultMat.release();
+                        }
+                        if (finalInterpretationResult != null &&
+                                finalInterpretationResult.resultMat != null) {
                             finalInterpretationResult.resultMat.release();
                         }
                         if (result == RDTDectedResult.STOP) {

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageUtil.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageUtil.java
@@ -14,6 +14,7 @@ import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.YuvImage;
 import android.media.Image;
+import android.util.Base64;
 
 import org.opencv.android.Utils;
 import org.opencv.core.CvType;
@@ -132,6 +133,17 @@ public final class ImageUtil {
         return mat;
     }
 
+    public static String matToBase64(Mat mat) {
+        if (mat == null) {
+            return "";
+        }
+        Bitmap bitmap = Bitmap.createBitmap(mat.cols(), mat.rows(), Bitmap.Config.ARGB_8888);
+        Utils.matToBitmap(mat, bitmap);
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream);
+        byte[] byteArray = byteArrayOutputStream .toByteArray();
+        return Base64.encodeToString(byteArray, Base64.DEFAULT);
+    }
 
     public static byte[] matToRotatedByteArray(Mat captureMat) {
         Bitmap resultBitmap = Bitmap.createBitmap(captureMat.cols(), captureMat.rows(), Bitmap.Config.ARGB_8888);


### PR DESCRIPTION
This adds an `onRDTDetected` callback like the one I added for iOS. I moved the body of `moveToResultActivity` to `onRDTDetected` in `ImageQualityActivity`, and took a shot at cleaning up the last part of `ImageProcessAsyncTask#doInBackground` where the callback now gets invoked.

It's unclear if opencv `Mat`s actually need to be explicitly `release()`'d when you're working in Java, but it probably doesn't hurt.