### PR TITLE
Add onRDTInterpreting callback

### DIFF
--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/ImageQualityView.java
@@ -107,6 +107,7 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
                 ImageProcessor.InterpretationResult interpretationResult,
                 long timeTaken
         );
+        void onRDTInterpreting(long timeTaken);
     }
 
     public ImageQualityView(Context context, AttributeSet attrs) {
@@ -347,6 +348,21 @@ public class ImageQualityView extends LinearLayout implements View.OnClickListen
             ImageProcessor.InterpretationResult interpretationResult = null;
             if (captureResult.allChecksPassed) {
                 Log.d(TAG, String.format("Captured MAT size: %s", captureResult.resultMat.size()));
+                if (mImageQualityViewListener != null) {
+                    mImageQualityViewListener.onRDTInterpreting(System.currentTimeMillis() - timeTaken);
+                }
+                try {
+                    mCameraOpenCloseLock.acquire();
+                    if (null != mCaptureSession) {
+                        mCaptureSession.stopRepeating();
+                    }
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } catch (CameraAccessException e) {
+                    e.printStackTrace();
+                } finally {
+                    mCameraOpenCloseLock.release();
+                }
 
                 //interpretation
                 interpretationResult = processor.interpretResult(captureResult.resultMat, captureResult.boundary);


### PR DESCRIPTION
Adds a callback for us to show a spinner during result interpretation on Android. Also freezes the camera preview while that's happening.