### PR TITLE
Bump target SDK version to 28 (Nov 1 deadline)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,11 +26,11 @@ def getVersionName = {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     defaultConfig {
         applicationId "edu.washington.cs.ubicomplab.rdt_reader"
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode getVersionCode()
         versionName getVersionName()
         archivesBaseName = "${project.name}-${versionName}"


### PR DESCRIPTION
This change needs to be deployed to the Play Store before November 1st to avoid being delisted.
#32 